### PR TITLE
similar product recommendation

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/Team_Romulus_Zuri_MarketPlace.iml
+++ b/.idea/Team_Romulus_Zuri_MarketPlace.iml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="django" name="Django">
+      <configuration>
+        <option name="rootFolder" value="$MODULE_DIR$" />
+        <option name="settingsModule" value="core/settings.py" />
+        <option name="manageScript" value="$MODULE_DIR$/manage.py" />
+        <option name="environment" value="&lt;map/&gt;" />
+        <option name="doNotUseTestRunner" value="false" />
+        <option name="trackFilePattern" value="migrations" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/myenv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.11 (Team_Romulus_Zuri_MarketPlace)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_CONFIGURATION" value="Django" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,84 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="HtmlUnknownAttribute" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myValues">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="text-end" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
+    <inspection_tool class="HttpUrlsUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredUrls">
+        <list>
+          <option value="http://localhost" />
+          <option value="http://127.0.0.1" />
+          <option value="http://0.0.0.0" />
+          <option value="http://www.w3.org/" />
+          <option value="http://json-schema.org/draft" />
+          <option value="http://java.sun.com/" />
+          <option value="http://xmlns.jcp.org/" />
+          <option value="http://javafx.com/javafx/" />
+          <option value="http://javafx.com/fxml" />
+          <option value="http://maven.apache.org/xsd/" />
+          <option value="http://maven.apache.org/POM/" />
+          <option value="http://www.springframework.org/schema/" />
+          <option value="http://www.springframework.org/tags" />
+          <option value="http://www.springframework.org/security/tags" />
+          <option value="http://www.thymeleaf.org" />
+          <option value="http://www.jboss.org/j2ee/schema/" />
+          <option value="http://www.jboss.com/xml/ns/" />
+          <option value="http://www.ibm.com/webservices/xsd" />
+          <option value="http://activemq.apache.org/schema/" />
+          <option value="http://schema.cloudfoundry.org/spring/" />
+          <option value="http://schemas.xmlsoap.org/" />
+          <option value="http://cxf.apache.org/schemas/" />
+          <option value="http://primefaces.org/ui" />
+          <option value="http://tiles.apache.org/" />
+          <option value="http://bidout.up.railway.app" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="6">
+            <item index="0" class="java.lang.String" itemvalue="Django" />
+            <item index="1" class="java.lang.String" itemvalue="mysqlclient" />
+            <item index="2" class="java.lang.String" itemvalue="django-heroku" />
+            <item index="3" class="java.lang.String" itemvalue="psycopg2" />
+            <item index="4" class="java.lang.String" itemvalue="python-decouple-3.8" />
+            <item index="5" class="java.lang.String" itemvalue="numpy" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="N806" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyShadowingBuiltinsInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredNames">
+        <list>
+          <option value="format" />
+          <option value="id" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="auctions.forms.BidForm.CommentForm.*" />
+          <option value="events.views.EventRetrieveAPIView" />
+          <option value="type.with_ui" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (Team_Romulus_Zuri_MarketPlace)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Team_Romulus_Zuri_MarketPlace.iml" filepath="$PROJECT_DIR$/.idea/Team_Romulus_Zuri_MarketPlace.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/MarketPlace/serializers.py
+++ b/MarketPlace/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from .models import Product
+
+
+class ProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product
+        fields = '__all__'

--- a/MarketPlace/urls.py
+++ b/MarketPlace/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from  .views import SimilarProductView
+
+urlpatterns = [
+    path('similar_products/<uuid:product_id>/', SimilarProductView.as_view(), name='similar-products'),
+]

--- a/MarketPlace/views.py
+++ b/MarketPlace/views.py
@@ -1,3 +1,29 @@
-from django.shortcuts import render
+from django.http import Http404
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from .models import Product
+from .serializers import ProductSerializer
+import random
 
-# Create your views here.
+
+class SimilarProductView(APIView):
+    @staticmethod
+    def get(request, product_id):
+        try:
+            current_product = Product.objects.get(id=product_id)
+        except Product.DoesNotExist:
+            return Response({'error': 'Product not found'}, status=status.HTTP_404_NOT_FOUND)
+
+        similar_products = Product.objects.filter(category=current_product.category).exclude(id=product_id)
+
+        similar_products = list(similar_products)
+        random.shuffle(similar_products)
+
+        recommended_products = similar_products[:4]
+
+        serializer = ProductSerializer(recommended_products, many=True)
+
+        return Response({'similar_products': serializer.data}, status=status.HTTP_200_OK)
+
+

--- a/core/urls.py
+++ b/core/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include('MarketPlace.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 asgiref==3.7.2
 Django==4.2.6
 sqlparse==0.4.4
+
+djangorestframework~=3.14.0


### PR DESCRIPTION
### Description 

Created endpoint is for recommending similar products to users based on when they are currently viewing in the product details page.

Serializer Configuration: The serializers.py file defines a serializer class, ProductSerializer, which handles the serialization and deserialization of product data. It specifies the model and fields to include in the serialized data.


URL Pattern: The urls.py file defines a URL pattern that maps the similar_products/<uuid:product_id>/  endpoint to the add_to_wishlist view. Users can make POST requests to this endpoint to add products to their wishlist.​

### Related Issue (Link to linear ticket)
[https://linear.app/zuri-project-backend/issue/MAR-20/similar-products](url)


### Motivation and Context
the endpoint is for recomending similar products when viewing a product deatails page


### Types of Changes

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x]  My code follows the code style of this project.

- [ ]  My change requires a change to the documentation.

 

- [ ] I have updated the documentation accordingly.

 

- [ ] I have read the CONTRIBUTING document.

- [ ]  I have added tests to cover my changes.

- [ ] All new and existing tests passed.