### PR TITLE
Bug fix for `TestGetAllProductsBasedOnCategory` Unittest

### DIFF
--- a/MarketPlace/tests.py
+++ b/MarketPlace/tests.py
@@ -61,7 +61,7 @@ class TestGetAllProductsBasedOnCategory(TestCase):
         )
 
     def test_get_all_products_by_category(self):
-        url = reverse("get_products_by_categories", args=[self.test_category1])
+        url = reverse("get_all_products_by_categories", args=[self.test_category1])
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotEqual(len(response.data), None)
@@ -70,7 +70,7 @@ class TestGetAllProductsBasedOnCategory(TestCase):
         print(response.data)
 
     def test_get_empty_products_list_by_category(self):
-        url = reverse("get_products_by_categories", args=[self.test_category2])
+        url = reverse("get_all_products_by_categories", args=[self.test_category2])
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -79,7 +79,7 @@ class TestGetAllProductsBasedOnCategory(TestCase):
 
     def test_return_404_for_nonexistent_category(self):
         nonexistent_category = "NonExistentCategory"
-        url = reverse("get_products_by_categories",
+        url = reverse("get_all_products_by_categories",
                       args=[nonexistent_category])
         response = self.client.get(url)
 


### PR DESCRIPTION

## Description
- Changed `get_products_by_categories` to `get_all_products_by_categories` for  each reversed url.
​
## Related Issue (Link to linear ticket)
- [Linear](https://linear.app/zuri-project-backend/issue/MAR-12/write-out-a-unit-test-for-the-endpoint-get-all-products-based-on)
​
## Motivation and Context
- This changed is required for the unittests for `TestGetAllProductsBasedOnCategory` to run successfully.
​
## How Has This Been Tested?
- Three(3) successful tests were run using `python3 manage.py test MarketPlace.tests`.
​
## Screenshots (if appropriate - Postman, etc):
- [Unittest](https://drive.google.com/file/d/1CpwzY-05Z5yo0rL7wETPzPVuokQ3xEJD/view?usp=drive_link)
​
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.