### PR TITLE
added category_names url

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -47,4 +47,5 @@ urlpatterns = [
     path('api/', include('add_to_wishlist.urls')),
     path('api/', include('addrecent.urls')),
     path('api/', include('product_category.urls')),
+    path('api/', include('category_names.urls'))
 ]


### PR DESCRIPTION
## Description

Added `category_names` URL to core, which was mistakenly removed.
​
## Related Issue (Link to linear ticket)

- [Linear](https://linear.app/zuri-project-backend/issue/MAR-55/create-endpoint-for-category-slider-to-retrieve-categorysubcategory)

​
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
