### PR TITLE
Added functionality to retrurn currency symbol along with product detail

### DIFF
--- a/addrecent/currencies.py
+++ b/addrecent/currencies.py
@@ -1,0 +1,31 @@
+#this file will contain currency codes and their corresponding currency symbol
+
+currency_data = {
+    'USD': '$',  # United States Dollar
+    'EUR': '€',  # Euro
+    'GBP': '£',  # British Pound Sterling
+    'JPY': '¥',  # Japanese Yen
+    'AUD': 'A$',  # Australian Dollar
+    'CAD': 'C$',  # Canadian Dollar
+    'CHF': 'Fr',  # Swiss Franc
+    'CNY': '元',  # Chinese Yuan Renminbi
+    'SEK': 'kr',  # Swedish Krona
+    'NZD': 'NZ$',  # New Zealand Dollar
+    'INR': '₹',  # Indian Rupee
+    'SGD': 'S$',  # Singapore Dollar
+    'NGN': '₦',  # Nigerian Naira
+    'HRK': 'kn',  # Croatian Kuna
+    'CZK': 'Kč',  # Czech Koruna
+    'ISK': 'kr',  # Icelandic Króna
+    'RON': 'lei',  # Romanian Leu
+    'CHF': 'Fr',  # Swiss Franc
+    'GBP': '£',  # British Pound Sterling
+    'CAD': 'C$',  # Canadian Dollar
+    'GHS': 'GH₵',  # Ghanaian Cedi
+    'KES': 'Ksh',  # Kenyan Shilling
+    'ZAR': 'R',  # South African Rand
+    'IDR': 'Rp',  # Indonesian Rupiah
+    'KRW': '₩',  # South Korean Won
+    'THB': '฿',  # Thai Baht
+    'ETB': 'Br',  # Ethiopian Birr
+}

--- a/addrecent/serializers.py
+++ b/addrecent/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from MarketPlace.models import UserProductInteraction
 from MarketPlace.models import Product
+from .currencies import currency_data
 
 class UserProductInteractionSerializer(serializers.ModelSerializer):
     class Meta:
@@ -8,6 +9,18 @@ class UserProductInteractionSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 class ProductItemSerializer(serializers.ModelSerializer):
+    currency_symbol = serializers.SerializerMethodField(read_only=True)
     class Meta:
         model = Product
-        fields = '__all__'
+        fields = [
+			'id', 'shop', 'name', 'description', 'quantity', 'category', 'price',
+			'discount_price', 'tax', 'admin_status', 'is_deleted', 'rating', 'is_published',
+			'currency', 'currency_symbol', 'createdat', 'updatedat', 'user'
+		]
+
+    def get_currency_symbol(self, obj):
+        currency_code = getattr(obj, 'currency')#getting the currency code of the product 
+        currency_symobol = currency_data.get(currency_code, "$")#getting the corresponding currency symbol default of dollar symbol if the symbol is not found
+        return currency_symobol
+
+

--- a/addrecent/views.py
+++ b/addrecent/views.py
@@ -17,8 +17,7 @@ class CreateRecentlyViewd(generics.GenericAPIView):
         user_id = kwargs.get('user_id')
         product_id = kwargs.get('product_id')
 
-        query_response = addRecentlyViewed(user_id=user_id, product_id=product_id)
-        print('the status code of the response is ', query_response.status_code)
+        query_response = addRecentlyViewed(user_id=user_id, product_id=product_id)#this function attempts to create a recently viewed and returns a Response 
         return Response(query_response.data)        
 
 
@@ -35,14 +34,14 @@ class GetProductItem(generics.RetrieveAPIView):
         
         user_id = kwargs.get('user_id')
         product_id = kwargs.get('id')
-        qurery_response = addRecentlyViewed(user_id=user_id, product_id=product_id)
-        if qurery_response.status_code == status.HTTP_201_CREATED:
+        qurery_response = addRecentlyViewed(user_id=user_id, product_id=product_id)#this function attempts to create a recently viewed and returns a Response
+        if qurery_response.status_code == status.HTTP_201_CREATED:#this means the product has been added to recently viewed succesfully
             return super().retrieve(request, *args, **kwargs)
         else:
             return Response(qurery_response.data, status= qurery_response.status_code)
 
 
-"""This function adds updates the users recently viewed"""
+"""This function adds updates the users recently viewed and returns a resonse object"""
 def addRecentlyViewed(user_id, product_id):
     current_time = timezone.now()#getting the current time 
     serializer_data = {
@@ -52,7 +51,7 @@ def addRecentlyViewed(user_id, product_id):
         "createdat": current_time
     }#constructing a data for the serializer
 
-    serializer = UserProductInteractionSerializer(data=serializer_data)
+    serializer = UserProductInteractionSerializer(data=serializer_data)#initailizing a serializer for the provided data
     if serializer.is_valid():
         try: 
             user = User.objects.get(id = user_id)
@@ -67,7 +66,7 @@ def addRecentlyViewed(user_id, product_id):
 
         last_viewed = LastViewedProduct.objects.filter(user=user)
         if last_viewed.exists():
-            #deleting the previous last_viewed object corresponding to this user 
+            #deleting the previous last_viewed object corresponding to this user, user cant have two last viewed 
             last_viewed.delete()
         
         last_viewed_object = LastViewedProduct.objects.create(user=user,product=product, viewed_at =current_time)#creating a new last_viewed object 
@@ -77,10 +76,7 @@ def addRecentlyViewed(user_id, product_id):
         if recently_viewed.exists():
             #deleting the recent views with thesame user and thesame product because user cant reently view one product twice :)
             recently_viewed.delete()
-            print('recently_viewed deleted')
-        else:
-            print('recently viewed does not exist')
-
+        
         serializer.save()
         context = {
             'message': 'History updated successfully',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added functionality to retrurn currency symbol along with product detail

​
## Description
<!--- Describe your changes in detail -->
getting the corresponding currency symbol of the associated currency and returning in the response of the product detail in the getproduct endpoint, Front end developers should use the currency symbol instead of hard coding it on the frontend which can lead to wrong currency and currency symbol association 
​
## Related Issue (Link to linear ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://linear.app/zuri-project-backend/issue/MAR-51/a-new-endpoint-for-currency-conversion-can-be-used-to-convert-the
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In our current frontend, the dollar sign is hardcoded but some currencies in the database are not dollar hence the need for a dynamic retrieval of the correct currency symbol 
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual tests using postman to send a request to the getproduct endpoint 
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ `x` ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ `x` ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [`x`  ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ `x` ] All new and existing tests passed.
