### PR TITLE
Task/BugFix/Product-Category  

### DIFF
--- a/category_names/views.py
+++ b/category_names/views.py
@@ -34,5 +34,11 @@ class CategoryNameView(APIView):
             
             return Response(response, status=status.HTTP_200_OK)
         except Exception as e:
+            response = {
+                'status': status.HTTP_500_INTERNAL_SERVER_ERROR,
+                'error': True,
+                'message': str(e),
+                'data': {'error': 'An unexpected error occurred'}
+            }
             
-            return Response({'message': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Description

- Performed fixes on the `category` type check and exception-handling block codes.

​
## Related Issue (Link to linear ticket)
​
## Motivation and Context

-  The check to ensure that `category` is a string should be at the beginning of the function to validate the input before attempting to query the database.
- The `try...except` block should contain the `product_category` and `products` retrieval codes.
​
## How Has This Been Tested?
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.