### PR TITLE
Task/BugFix/Product-Category

### DIFF
--- a/product_category/views.py
+++ b/product_category/views.py
@@ -13,13 +13,13 @@ from django.core.paginator import Paginator
 class ProductListByCategoryView(APIView):
     def get(self, request, category):
         # sort_by = request.query_params.get('sort_by', 'name')
-        product_category = ProductCategory.objects.get(name=category)
-        products = Product.objects.filter(category=product_category, is_deleted='active', admin_status='approved')
-
         if not isinstance(category, str):
             return Response({"error": "Category name must be a string value"}, status=status.HTTP_400_BAD_REQUEST)
-
+        
         try:
+            product_category = ProductCategory.objects.get(name=category)
+            products = Product.objects.filter(category=product_category, is_deleted='active', admin_status='approved')
+
             if not products.exists():
                 return Response({"status": 200, "success": True, "data": [],
                                  'message': 'The Category exists, but has no products'},
@@ -34,6 +34,5 @@ class ProductListByCategoryView(APIView):
             return Response({"status": 404, "success": False, 'message': 'Category does not exist.'},
                             status=status.HTTP_404_NOT_FOUND)
         except Exception as e:
-            return Response({"status": 500, "success": False, 'error': e, "message": f"An unexpected error occurred: {str(e)}"},
+            return Response({"status": 500, "success": False, 'error': str(e), "message": f"An unexpected error occurred: {str(e)}"},
                             status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-


### PR DESCRIPTION
## Description

- Performed fixes on the `category` type check and exception-handling block codes.

​
## Related Issue (Link to linear ticket)
​
## Motivation and Context

-  The check to ensure that `category` is a string should be at the beginning of the function to validate the input before attempting to query the database.
- The `try...except` block should contain the `product_category` and `products` retrieval codes.
​
## How Has This Been Tested?
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.