### PR TITLE
Add rate limiting to search endpoint

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -195,6 +195,16 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 5,
 }
+REST_FRAMEWORK = {
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle'
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '100/hour',
+        'user': '1000/hour'
+    }
+}
 
 STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"

--- a/product_retrieval/views.py
+++ b/product_retrieval/views.py
@@ -4,6 +4,13 @@ from rest_framework.pagination import PageNumberPagination
 from MarketPlace.models import Product
 from all_products.serializers import AllProductSerializer as ProductSerializer
 from django.db.models import Q
+from rest_framework.throttling import UserRateThrottle
+
+class ProductSearchRateThrottle(UserRateThrottle):
+    rate = '50/hour'
+
+class ProductSearchView(APIView):
+    throttle_classes = [ProductSearchRateThrottle]
 
 class ProductSearchView(APIView):
 


### PR DESCRIPTION
## Description

- Added rate limiting to the Product Retrieval endpoint to prevent excessive requests from a single user."

​
## Related Issue (Link to linear ticket)
​
## Motivation and Context

-  The check to ensure that `category` is a string should be at the beginning of the function to validate the input before attempting to query the database.
- The `try...except` block should contain the `product_category` and `products` retrieval codes.
​
## How Has This Been Tested?
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.