### PR TITLE
Wishlist datetime

### DIFF
--- a/add_to_wishlist/views.py
+++ b/add_to_wishlist/views.py
@@ -67,13 +67,13 @@ class WishlistCreateView(views.APIView):
 
         try:
             # Retrieve product details
-            Product.objects.get(id=product_id)
+            product = Product.objects.get(id=product_id)
         except ObjectDoesNotExist:
             return Response({"message": "Product not found."}, status=status.HTTP_404_NOT_FOUND)
 
         # Add the product to the user's wishlist
         wishlist_item, created = Wishlist.objects.get_or_create(
-            user_id=user.id, product_id=product_id)  
+            user_id=user.id, product=product)  
 
         serializer = self.serializer_class(wishlist_item)
 

--- a/add_to_wishlist/views.py
+++ b/add_to_wishlist/views.py
@@ -7,6 +7,8 @@ from .serializers import WishlistSerializer
 from django.core.exceptions import ObjectDoesNotExist
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
+from datetime import datetime
+
 
 
 class WishlistCreateView(views.APIView):
@@ -74,6 +76,13 @@ class WishlistCreateView(views.APIView):
         # Add the product to the user's wishlist
         wishlist_item, created = Wishlist.objects.get_or_create(
             user_id=user.id, product=product)  
+        
+        #set createdat and updated at to current time
+        now = datetime.now()
+        wishlist_item.createdat = now
+        wishlist_item.updatedat = now
+        wishlist_item.save()
+
 
         serializer = self.serializer_class(wishlist_item)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
Enhance WishlistCreateView with timestamp handling

Updated WishlistCreateView to include "createdat" and "updatedat" timestamps for Wishlist objects. These timestamps are set to the current datetime when a new Wishlist item is created or an existing one is updated.

​
## Related Issue (Link to linear ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​
## Screenshots (if appropriate - Postman, etc):
![aaaaaaaaaaaaaal](https://github.com/hngx-org/Team_Romulus_Zuri_MarketPlace/assets/62937590/8a3b7a80-ddcb-4131-8fa0-bbd3b98e2df4)

​
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
