### PR TITLE
Improve exception handling

### DIFF
--- a/product_retrieval/views.py
+++ b/product_retrieval/views.py
@@ -1,9 +1,10 @@
-from django.core.paginator import Paginator
+from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.db.models import Q, Value, CharField
 from django.db.models.functions import Replace, Concat
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
+from rest_framework.exceptions import ParseError, ValidationError
 from MarketPlace.models import Product
 from all_products.serializers import AllProductSerializer as ProductSerializer
 
@@ -21,7 +22,7 @@ class ProductSearchView(APIView):
         """
         query = request.query_params.get('search', None)
         if not query:
-            return Response({"status": "error", "message": "A search term must be provided."}, status=400)
+            raise ParseError({"status": "error", "message": "A search term must be provided.", "status_code": 400})
 
         try:
             # Highlighting logic
@@ -38,7 +39,14 @@ class ProductSearchView(APIView):
             # Manual Pagination
             page = request.query_params.get('page', 1)
             paginator = Paginator(products, 10)  # 10 items per page
-            current_page = paginator.get_page(page)
+            try:
+                current_page = paginator.page(page)
+            except PageNotAnInteger:
+                # If page is not an integer, deliver first page.
+                current_page = paginator.page(1)
+            except EmptyPage:
+                # If page is out of range, deliver last page of results.
+                current_page = paginator.page(paginator.num_pages)
 
             serializer = ProductSerializer(current_page, many=True)
 
@@ -57,5 +65,7 @@ class ProductSearchView(APIView):
 
             return Response(response_data)
 
+        except ValueError as e:
+            raise ValidationError(f"Error processing request: {str(e)}")
         except Exception as e:
             return Response({"status": "error", "message": f"An unexpected error occurred: {str(e)}"}, status=500)


### PR DESCRIPTION
## Description

1. I've imported ParseError and ValidationError from DRF for more context-specific error responses.
2. Modified the way pagination errors are handled. Now, if the page is not an integer, it defaults to the first page. If the page is out of range, it defaults to the last page of results.
3. Provided more specific error handling for ValueError occurrences.

​
## Related Issue (Link to linear ticket)
​
## Motivation and Context

In our pursuit of building robust and user-friendly applications, distinguishing between error types is essential. Leveraging Django's built-in exceptions allows us to provide clearer feedback to end-users and aids developers in quickly pinpointing issues. This enhancement not only elevates the user experience by offering precise error messages but also aligns our codebase with best practices in Django development.

## How Has This Been Tested?
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.